### PR TITLE
Changed 'relaxerror' method to compare Strings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,6 +91,23 @@ module.exports = function(grunt) {
                     src: ['test/html/invalid/improperly_nested_tags.tmpl.html']
                 }
             },
+            improper_angular_operator: {
+                options: {
+                },
+                files: {
+                    src: ['test/html/invalid/improper_angular_operator.tmpl.html']
+                }
+            },
+            improper_angular_operator_relaxed: {
+                options: {
+                    relaxerror: [
+                        '& did not start a character reference. (& probably should have been escaped as &amp;.)'
+                    ],
+                },
+                files: {
+                    src: ['test/html/invalid/improper_angular_operator.tmpl.html']
+                }
+            }
         },
 
         // Unit tests.

--- a/tasks/htmlangular.js
+++ b/tasks/htmlangular.js
@@ -109,8 +109,7 @@ module.exports = function(grunt) {
 
         var checkRelaxed = function(errmsg) {
             for (var i = 0; i < options.relaxerror.length; i += 1) {
-                var re = new RegExp(options.relaxerror[i], 'g');
-                if (re.test(errmsg)) {
+                if (errmsg.indexOf(options.relaxerror[i]) !== -1) {
                     return true;
                 }
             }

--- a/test/html/invalid/improper_angular_operator.tmpl.html
+++ b/test/html/invalid/improper_angular_operator.tmpl.html
@@ -1,0 +1,1 @@
+<p ng-if="true&&true"></p>

--- a/test/htmlangluar_test.js
+++ b/test/htmlangluar_test.js
@@ -142,4 +142,26 @@ exports.tests = {
             test.done();
         });
     },
+    improper_angular_operator: function(test) {
+        test.expect(1);
+        exec('grunt htmlangular:improper_angular_operator', execOptions, function(error, stdout) {
+            test.equal(
+                stdout.indexOf('& did not start a character reference. (& probably should have been escaped as &amp;.)') > -1,
+                true,
+                'found && in expression'
+            );
+            test.done();
+        });
+    },
+    improper_angular_operator_relaxed: function(test) {
+        test.expect(1);
+        exec('grunt htmlangular:improper_angular_operator_relaxed', execOptions, function(error, stdout) {
+            test.equal(
+                stdout.indexOf('& did not start a character reference. (& probably should have been escaped as &amp;.)') === -1,
+                true,
+                'relaxed ignored error'
+            );
+            test.done();
+        });
+    }
 };


### PR DESCRIPTION
`option.relaxerror` entries were being compared as regular expressions, which doesn't appear to be necessary, and would fail when trying to relax an error like `'& did not start a character reference. (& probably should have been escaped as &amp;.)'` that includes unescaped RegEx characters.

Have altered the `checkRelaxed()` method to compare Strings instead.
