### PR TITLE
Add support for concurrently validating files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,19 @@ module.exports = function(grunt) {
                     src: ['test/html/valid/**/*.html']
                 }
             },
+            default_options_concurrent: {
+                options: {
+                    customtags: ['custom-tag', 'custom-*'],
+                    customattrs: ['fixed-div-label', 'custom-*'],
+                    wrapping: {
+                        'tr': '<table>{0}</table>'
+                    },
+                    concurrentJobs: 4
+                },
+                files: {
+                    src: ['test/html/valid/**/*.html']
+                }
+            },
             missing_wrapping: {
                 options: {
                 },

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ While there are other Grunt plugins that will validate HTML files, there are lac
 
  * Support for AngularJS attributes and tags (both from AngularJS and custom created)
  * Support for templated/fragmented HTML files
+ * Ability to concurrently validate files for greatly increased speed
 
 This plugin looks to solve these problems and provide the value that comes with having HTML validation in the build chain.
 
@@ -136,6 +137,12 @@ Default value: `null`
 
 The proxy to the W3C validator service. Use this as an alternative when running a local instance of the W3C validator service
 (e.g. `http://localhost:8080`). Do not use in conjunction with `optinos.w3clocal`.
+
+###options.concurrentJobs
+Type: `Integer`
+Default value: `1`
+
+The maximum number of validation jobs to run concurrently. Using a number greater than `1` can greatly increase validation speed with many files, especially when running a local validation server.
 
 ### Usage Examples
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "w3cjs": "~0.1.25",
     "colors": "~0.6.2",
-    "temporary": "~0.0.8"
+    "temporary": "~0.0.8",
+    "async": "~0.9.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"

--- a/test/htmlangluar_test.js
+++ b/test/htmlangluar_test.js
@@ -40,6 +40,17 @@ exports.tests = {
             test.done();
         });
     },
+    default_options_concurrent: function(test) {
+        test.expect(1);
+        exec('grunt htmlangular:default_options_concurrent', execOptions, function(error, stdout) {
+            test.equal(
+                stdout.indexOf('6 files passed validation') > -1,
+                true,
+                'valid files pass'
+            );
+            test.done();
+        });
+    },
     missing_wrapping: function(test) {
         test.expect(4);
         exec('grunt htmlangular:missing_wrapping', execOptions, function(error, stdout) {


### PR DESCRIPTION
Howdy there!

First, thanks for an awesome Grunt task! We're using this on the Rackspace Cloud Intelligence team as part of the test process on our build server, and it's been working great for us.

One issue we've had is that validation is performed one file at a time in serial. Our project has hundreds of views to validate, so it takes ~2.5 minutes to run a full validation.

We've found that we can speed this up greatly by validating a files in parallel; when testing against a beefy 32-core HTML validation server with 32 concurrent jobs, it takes less than 5 seconds to check the entire project (versus 2.5 minutes in serial).

I've modified your task to allow parallel execution. It uses the awesome (and tiny) [async](https://github.com/caolan/async) library to validate files in parallel with a configurable concurrency limit. I've made a couple minor changes to the code to keep the complexity low:
- Switching out the home-baked linked-list implementation for arrays, which means we can use standard functional approaches to concurrency (like `map`). This also makes some other parts of the code simpler.
- Removed `validate` function side effects so that we can safely run it in parallel; it returns its result (success boolean). These get counted to provide the `succeedCount` to `finished`.

There's one functionality change, which is that if validation fails more than the allowed number of times, it now stops attempting to validate the remaining views. In our experience, validation usually fails when the validation server blocks you for too many requests, and you then have to wait a long time for the rest of the views to also fail, further bombarding the server. I'm happy to revert this change if you don't like it.

Would love to work with you to help get this merged! Cheers!
